### PR TITLE
Fix tooltip removal for suns and planets

### DIFF
--- a/apps/web/src/features/layout/components/Starfield/hooks/animation/animate.ts
+++ b/apps/web/src/features/layout/components/Starfield/hooks/animation/animate.ts
@@ -418,6 +418,10 @@ export const animate = (
         props.setHoveredSunId(null);
         props.setHoveredSun(null);
         lastSunLeaveTime = null;
+        // Reset the tooltip ref since the tooltip will be unmounted
+        if (props.isMouseOverSunTooltipRef) {
+          props.isMouseOverSunTooltipRef.current = false;
+        }
       } else if (!currentHoverInfo.show) {
         // Only check sun hover when no planet tooltip is showing
         const sunHoverResult = checkSunHover(
@@ -443,9 +447,9 @@ export const animate = (
               y: sunHoverResult.y,
             });
           }
-        } else if (props.isMouseOverSunTooltipRef?.current) {
-          // Mouse is over the tooltip - clear any pending leave time
-          // This prevents the hover from clearing while interacting with the tooltip
+        } else if (props.hoveredSunId !== null && props.isMouseOverSunTooltipRef?.current) {
+          // Mouse is over the tooltip (only valid when sun is hovered and tooltip is rendered)
+          // Clear any pending leave time to prevent hover from clearing while interacting
           lastSunLeaveTime = null;
         } else if (props.hoveredSunId !== null) {
           // Mouse has left the sun and is not over the tooltip
@@ -460,10 +464,17 @@ export const animate = (
             props.setHoveredSunId(null);
             props.setHoveredSun(null);
             lastSunLeaveTime = null; // Reset for next hover
+            // Reset the tooltip ref since the tooltip will be unmounted
+            if (props.isMouseOverSunTooltipRef) {
+              props.isMouseOverSunTooltipRef.current = false;
+            }
           }
-        } else if (props.hoveredSunId === null) {
-          // No sun is hovered and none was previously hovered - reset leave time
+        } else {
+          // No sun is hovered - reset leave time and tooltip ref
           lastSunLeaveTime = null;
+          if (props.isMouseOverSunTooltipRef) {
+            props.isMouseOverSunTooltipRef.current = false;
+          }
         }
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents overlapping planet and sun tooltips so only one displays at a time.
  * Keeps tooltips from disappearing when the cursor is over them by preserving and clearing tooltip timers appropriately.
  * Resets hover state references when hiding tooltips to avoid phantom hover behavior and ensure consistent tooltip transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->