### PR TITLE
fix(starfield): reset tooltip ref when sun hover is cleared

### DIFF
--- a/apps/web/src/features/layout/components/Starfield/hooks/animation/animate.ts
+++ b/apps/web/src/features/layout/components/Starfield/hooks/animation/animate.ts
@@ -418,6 +418,10 @@ export const animate = (
         props.setHoveredSunId(null);
         props.setHoveredSun(null);
         lastSunLeaveTime = null;
+        // Reset the tooltip ref since the tooltip will be unmounted
+        if (props.isMouseOverSunTooltipRef) {
+          props.isMouseOverSunTooltipRef.current = false;
+        }
       } else if (!currentHoverInfo.show) {
         // Only check sun hover when no planet tooltip is showing
         const sunHoverResult = checkSunHover(
@@ -443,9 +447,9 @@ export const animate = (
               y: sunHoverResult.y,
             });
           }
-        } else if (props.isMouseOverSunTooltipRef?.current) {
-          // Mouse is over the tooltip - clear any pending leave time
-          // This prevents the hover from clearing while interacting with the tooltip
+        } else if (props.hoveredSunId !== null && props.isMouseOverSunTooltipRef?.current) {
+          // Mouse is over the tooltip (only valid when sun is hovered and tooltip is rendered)
+          // Clear any pending leave time to prevent hover from clearing while interacting
           lastSunLeaveTime = null;
         } else if (props.hoveredSunId !== null) {
           // Mouse has left the sun and is not over the tooltip
@@ -460,10 +464,17 @@ export const animate = (
             props.setHoveredSunId(null);
             props.setHoveredSun(null);
             lastSunLeaveTime = null; // Reset for next hover
+            // Reset the tooltip ref since the tooltip will be unmounted
+            if (props.isMouseOverSunTooltipRef) {
+              props.isMouseOverSunTooltipRef.current = false;
+            }
           }
-        } else if (props.hoveredSunId === null) {
-          // No sun is hovered and none was previously hovered - reset leave time
+        } else {
+          // No sun is hovered - reset leave time and tooltip ref
           lastSunLeaveTime = null;
+          if (props.isMouseOverSunTooltipRef) {
+            props.isMouseOverSunTooltipRef.current = false;
+          }
         }
       }
     }


### PR DESCRIPTION
The isMouseOverSunTooltipRef could get stuck at true when the sun tooltip was unmounted without onMouseLeave firing (e.g., when a planet tooltip appeared). This caused the sun hover effect to persist indefinitely.

Fixes:
1. Reset isMouseOverSunTooltipRef when clearing sun hover due to planet tooltip
2. Only trust isMouseOverSunTooltipRef when hoveredSunId is not null (meaning the tooltip is actually rendered)
3. Reset the ref when clearing sun hover after the delay timer
4. Reset the ref when no sun is hovered