### PR TITLE
fix: prevent stale isMouseOverProjectTooltipRef when tooltip unmounts

### DIFF
--- a/apps/web/src/features/layout/components/Starfield/Starfield.tsx
+++ b/apps/web/src/features/layout/components/Starfield/Starfield.tsx
@@ -260,6 +260,18 @@ const InteractiveStarfield = forwardRef<
       }
     }, [hoveredSunId]);
 
+    // ASSERTION: Clean up project tooltip ref when tooltip hides
+    // This prevents stale ref if tooltip unmounts before mouseLeave fires
+    useEffect(() => {
+      if (!hoverInfo.show) {
+        isMouseOverProjectTooltipRef.current = false;
+        if (projectTooltipHideTimeoutRef.current) {
+          clearTimeout(projectTooltipHideTimeoutRef.current);
+          projectTooltipHideTimeoutRef.current = null;
+        }
+      }
+    }, [hoverInfo.show]);
+
     // Internal camera state for sun zoom functionality
     const [internalCamera, setInternalCamera] = useState<Camera>({
       cx: CAMERA_CONFIG.defaultCenterX,


### PR DESCRIPTION
When the project tooltip unmounts before mouseLeave fires (due to animation loop clearing hoverInfo.show), the ref stays stuck as true, blocking sun hover detection. Added cleanup effect to reset the ref when hoverInfo.show becomes false, similar to existing cleanup for isMouseOverSunTooltipRef.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project tooltip cleanup to prevent display inconsistencies when the tooltip hides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->