### PR TITLE
Fix sun hover and scroll button alignment

### DIFF
--- a/apps/web/src/features/hero/components/Hero/Hero.tsx
+++ b/apps/web/src/features/hero/components/Hero/Hero.tsx
@@ -336,8 +336,8 @@ const Hero: FC<ExtendedHeroProps> = memo(
           {showScrollIndicator && (
             <motion.button
               className={styles.scrollIndicator}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1, y: [0, 10, 0] }}
+              initial={{ opacity: 0, x: "-50%" }}
+              animate={{ opacity: 1, x: "-50%", y: [0, 10, 0] }}
               exit={{ opacity: 0 }}
               transition={{
                 opacity: { duration: 0.5 },

--- a/apps/web/src/features/hero/components/Hero/hero.module.css
+++ b/apps/web/src/features/hero/components/Hero/hero.module.css
@@ -226,7 +226,7 @@
 }
 
 .scrollIndicator:hover {
-  transform: translateX(-50%) translateY(-5px);
+  /* Note: transform is controlled by framer-motion for proper centering with sidebar offset */
   background-color: rgba(147, 51, 234, 0.8); /* Darker purple on hover */
   border: 1px solid rgba(255, 255, 255, 0.3); /* Brighter border on hover */
   box-shadow: 0 5px 15px rgba(147, 51, 234, 0.4); /* Purple shadow on hover */

--- a/apps/web/src/features/layout/components/Starfield/Starfield.tsx
+++ b/apps/web/src/features/layout/components/Starfield/Starfield.tsx
@@ -233,6 +233,8 @@ const InteractiveStarfield = forwardRef<
     } = useCameraAnimation({
       focusedSunId,
       setFocusedSunId,
+      setHoveredSunId,
+      setHoveredSun,
       employeeStarsRef,
       dimensionsRef,
     });

--- a/apps/web/src/features/layout/components/Starfield/hooks/useCameraAnimation.ts
+++ b/apps/web/src/features/layout/components/Starfield/hooks/useCameraAnimation.ts
@@ -30,6 +30,10 @@ export interface CameraAnimationConfig {
   focusedSunId: string | null;
   /** Setter for focused sun ID */
   setFocusedSunId: (id: string | null) => void;
+  /** Setter for hovered sun ID (to reset on zoom out) */
+  setHoveredSunId: (id: string | null) => void;
+  /** Setter for hovered sun (to reset on zoom out) */
+  setHoveredSun: (sun: unknown) => void;
   /** Ref to employee stars (planets) for orbit radius calculation */
   employeeStarsRef: MutableRefObject<Planet[]>;
   /** Ref to canvas dimensions for zoom calculation */
@@ -55,6 +59,8 @@ export interface CameraAnimationResult {
 export function useCameraAnimation({
   focusedSunId,
   setFocusedSunId,
+  setHoveredSunId,
+  setHoveredSun,
   employeeStarsRef,
   dimensionsRef,
 }: CameraAnimationConfig): CameraAnimationResult {
@@ -91,6 +97,9 @@ export function useCameraAnimation({
       // If clicking on the same sun, toggle off (zoom out)
       if (focusedSunId === sunId) {
         setFocusedSunId(null);
+        // Reset hover state when zooming out
+        setHoveredSunId(null);
+        setHoveredSun(null);
 
         // Set camera target to zoom out
         setInternalCamera((prev) => ({
@@ -159,7 +168,7 @@ export function useCameraAnimation({
         },
       }));
     },
-    [focusedSunId, setFocusedSunId, employeeStarsRef, dimensionsRef],
+    [focusedSunId, setFocusedSunId, setHoveredSunId, setHoveredSun, employeeStarsRef, dimensionsRef],
   );
 
   // Smooth camera lerp animation - only runs when there's an active target


### PR DESCRIPTION
- Reset hoveredSunId and hoveredSun when zooming out from a focused sun to prevent stale hover state after zoom animation completes

- Fix scroll indicator centering by adding x: "-50%" to framer-motion animation to preserve horizontal centering while the y animation plays. Framer-motion was overriding the CSS transform, losing the translateX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced scroll indicator animation with improved horizontal centering for better visual alignment
  * Refined hover state management in interactive elements for more responsive user interactions
  * Fixed state reset behavior when toggling interactive elements to ensure clean interactions and prevent stale states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->