### PR TITLE
fix(mobile): 🐛 sync mousePositionRef immediately on touch/mouse events

### DIFF
--- a/apps/web/src/features/layout/components/Starfield/Starfield.tsx
+++ b/apps/web/src/features/layout/components/Starfield/Starfield.tsx
@@ -262,6 +262,9 @@ const InteractiveStarfield = forwardRef<
     });
 
     // Get mouse interaction hooks
+    // Pass mousePositionRef for synchronous updates on touch/mouse leave events
+    // This prevents the "stuck hover" bug where animation frames run before
+    // the async React state/useEffect flow propagates isOnScreen: false
     const { mousePosition, setMousePosition, handleMouseEvents } =
       useMouseInteraction(
         enableMouseInteraction,
@@ -270,6 +273,7 @@ const InteractiveStarfield = forwardRef<
         gameMode,
         gameState,
         setGameState,
+        mousePositionRef, // Pass ref for synchronous updates
       );
 
     useEffect(() => {

--- a/apps/web/src/features/layout/components/Starfield/hooks/useMouseInteraction.ts
+++ b/apps/web/src/features/layout/components/Starfield/hooks/useMouseInteraction.ts
@@ -1,5 +1,5 @@
 // components/Layout/Starfield/hooks/useMouseInteraction.ts
-import { useState, useRef, useCallback, useMemo } from "react";
+import { useState, useRef, useCallback, useMemo, MutableRefObject } from "react";
 import { MousePosition, Star, GameState } from "../types";
 import { applyClickForce } from "../stars";
 import { logger } from "@/utils/logger";
@@ -11,6 +11,8 @@ export const useMouseInteraction = (
   gameMode: boolean,
   gameState: GameState,
   setGameState: React.Dispatch<React.SetStateAction<GameState>>,
+  // Optional: external ref to sync for immediate updates (e.g., for animation loop)
+  externalMousePositionRef?: MutableRefObject<MousePosition>,
 ): {
   mousePosition: MousePosition;
   setMousePosition: React.Dispatch<React.SetStateAction<MousePosition>>;
@@ -56,6 +58,21 @@ export const useMouseInteraction = (
       if (now - lastMoveTimeRef.current < 16) return; // ~60fps
       lastMoveTimeRef.current = now;
 
+      // Update external ref SYNCHRONOUSLY for immediate animation loop access
+      if (externalMousePositionRef) {
+        const prev = externalMousePositionRef.current;
+        externalMousePositionRef.current = {
+          ...prev,
+          x: clientX,
+          y: clientY,
+          lastX: prev.x,
+          lastY: prev.y,
+          speedX: clientX - prev.x,
+          speedY: clientY - prev.y,
+          isOnScreen: true,
+        };
+      }
+
       setMousePosition((prev) => ({
         ...prev,
         x: clientX,
@@ -67,7 +84,7 @@ export const useMouseInteraction = (
         isOnScreen: true,
       }));
     },
-    [],
+    [externalMousePositionRef],
   );
 
   // Throttled mouse move handler
@@ -94,6 +111,21 @@ export const useMouseInteraction = (
   // Uses refs for game-related values to maintain stable callback identity
   const handlePointerDown = useCallback(
     (clientX: number, clientY: number): void => {
+      const clickTime = Date.now();
+
+      // CRITICAL FIX: Update external ref SYNCHRONOUSLY before React state update
+      // This ensures the animation loop sees isOnScreen: true immediately for touch
+      if (externalMousePositionRef) {
+        externalMousePositionRef.current = {
+          ...externalMousePositionRef.current,
+          x: clientX,
+          y: clientY,
+          isClicked: true,
+          clickTime,
+          isOnScreen: true,
+        };
+      }
+
       // Update mouse position
       // Also set isOnScreen: true for mobile touch support - without this,
       // hover detection won't run on touch because it checks isMouseOnScreen
@@ -102,7 +134,7 @@ export const useMouseInteraction = (
         x: clientX,
         y: clientY,
         isClicked: true,
-        clickTime: Date.now(),
+        clickTime,
         isOnScreen: true,
       }));
 
@@ -130,7 +162,7 @@ export const useMouseInteraction = (
         }));
       }
     },
-    [], // Empty deps - all values accessed via refs
+    [externalMousePositionRef], // Only externalMousePositionRef - other values accessed via refs
   );
 
   const handleMouseDown = useCallback(
@@ -166,22 +198,45 @@ export const useMouseInteraction = (
   const handleTouchEnd = useCallback((): void => {
     // On mobile, touch end is equivalent to mouse leave + mouse up
     // Clear both isClicked AND isOnScreen since finger has left the screen
+
+    // CRITICAL FIX: Update external ref SYNCHRONOUSLY before React state update
+    // This ensures the animation loop sees isOnScreen: false immediately,
+    // preventing the "stuck hover" bug where the sun hover ring persists
+    // because animation frames ran before the async state/useEffect propagated
+    if (externalMousePositionRef) {
+      externalMousePositionRef.current = {
+        ...externalMousePositionRef.current,
+        isClicked: false,
+        isOnScreen: false,
+      };
+    }
+
     setMousePosition((prev) => ({
       ...prev,
       isClicked: false,
       isOnScreen: false,
     }));
     logger.debug("Touch ended - cleared hover state");
-  }, []);
+  }, [externalMousePositionRef]);
 
   const handleMouseLeave = useCallback((): void => {
+    // CRITICAL FIX: Update external ref SYNCHRONOUSLY before React state update
+    // Same rationale as handleTouchEnd - prevents stuck hover states
+    if (externalMousePositionRef) {
+      externalMousePositionRef.current = {
+        ...externalMousePositionRef.current,
+        isOnScreen: false,
+        isClicked: false,
+      };
+    }
+
     setMousePosition((prev) => ({
       ...prev,
       isOnScreen: false,
       isClicked: false, // Ensure click is released when leaving screen
     }));
     logger.debug("Mouse left screen");
-  }, []);
+  }, [externalMousePositionRef]);
 
   // Event handlers object - memoized to prevent unstable identity causing
   // useEffect cleanup/setup cycles that remove event listeners permanently


### PR DESCRIPTION
The "stuck hover" bug on mobile was caused by a race condition between touch event handlers and the animation loop. When touchend fired, it called setMousePosition() which is async (React setState). The animation loop reads from mousePositionRef, which was updated via useEffect AFTER the state change. This meant animation frames could run with stale isOnScreen: true values before the ref update propagated.

The fix passes mousePositionRef to useMouseInteraction and updates it SYNCHRONOUSLY in all touch/mouse handlers (touchstart, touchmove, touchend, mouseleave) before the async setState call. This ensures the animation loop immediately sees the correct isOnScreen value, preventing the sun hover ring from getting stuck after touch ends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stuck hover state in the Starfield component during mouse and touch leave events.
  * Improved synchronization between user interactions and animation rendering to reduce input lag and prevent visual desynchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->