### PR TITLE
Make production optional jobs non-blocking

### DIFF
--- a/.github/actions/teams-notification/action.yml
+++ b/.github/actions/teams-notification/action.yml
@@ -226,6 +226,12 @@ runs:
     - name: Invoke Logic App HTTP Trigger
       shell: bash
       run: |
+        if [ -z "${{ inputs.logic_app_url }}" ]; then
+          echo "Logic App URL is empty; skipping Teams notification."
+          rm -f "${{ steps.build_payload.outputs.payload_file }}"
+          exit 0
+        fi
+
         echo "Invoking Logic App via HTTP trigger..."
         PAYLOAD_FILE="${{ steps.build_payload.outputs.payload_file }}"
         COMPACT_PAYLOAD=$(jq -c . < "$PAYLOAD_FILE")

--- a/.github/workflows/production_deployment.yml
+++ b/.github/workflows/production_deployment.yml
@@ -317,6 +317,7 @@ jobs:
           app_location: "docs/site"
           skip_app_build: true
           skip_api_build: true
+          skip_deploy_on_missing_secrets: true
 
       - name: Configure docs.phoenixvc.tech Custom Domain
         run: |
@@ -369,7 +370,7 @@ jobs:
             --resource-group "$RESOURCE_GROUP" \
             --name "$STATIC_WEB_APP_NAME" \
             --hostname "$DOMAIN" \
-            --query "status" -o tsv)
+            --query "status" -o tsv 2>/dev/null || echo "NotFound")
 
           echo "Domain status: $DOMAIN_STATUS"
 
@@ -415,11 +416,15 @@ jobs:
             --name "$STATIC_WEB_APP_NAME" \
             --query "defaultHostname" -o tsv)
 
-          az network dns record-set cname set-record \
+          if az network dns record-set cname set-record \
             --resource-group "$RESOURCE_GROUP" \
             --zone-name "$DOMAIN" \
             --record-set-name "@" \
-            --cname "$DEFAULT_HOSTNAME"
+            --cname "$DEFAULT_HOSTNAME"; then
+            echo "✅ DNS CNAME configured."
+          else
+            echo "⚠️ CNAME record was not updated. This is expected when apex DNS already uses other record types and the Static Web App hostname is Ready."
+          fi
 
           echo "✅ DNS configuration completed successfully."
 
@@ -427,7 +432,7 @@ jobs:
   # ✅ Notification Job
   # ───────────────────────────────────────────────
   notify_deployment:
-    needs: [swa_deploy_production, trigger_dns_update, deploy_docs, configure_custom_domain_dns]
+    needs: [deploy_resources_production, swa_deploy_production, trigger_dns_update, deploy_docs, configure_custom_domain_dns]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- skip docs SWA deploy cleanly when the docs deployment token is unavailable
- tolerate apex DNS CNAME conflicts once the production custom domain is already Ready
- wire production resource outputs into notification and skip Teams notification when the Logic App URL is missing

## Verification
- pre-commit lint passed with existing Starfield exhaustive-deps warning
- pre-commit format-check completed with existing repository formatting warnings (script exits 0)