### PR TITLE
fix(web): recover from chunk-preload failures + hide debug stack in prod

### DIFF
--- a/apps/web/src/features/error/ErrorBoundary.tsx
+++ b/apps/web/src/features/error/ErrorBoundary.tsx
@@ -1,6 +1,10 @@
 // features/error/ErrorBoundary.tsx
 import { Component, ErrorInfo, ReactNode } from "react";
 import { logger } from "@/utils/logger";
+import {
+  isChunkLoadError,
+  attemptChunkReload,
+} from "@/utils/chunkErrorRecovery";
 import styles from "./NotFound.module.css";
 
 interface Props {
@@ -13,6 +17,8 @@ interface State {
   hasError: boolean;
   error: Error | null;
   errorInfo: ErrorInfo | null;
+  /** True while a reload is pending to recover from a chunk-load failure. */
+  isReloading: boolean;
 }
 
 interface ErrorReport {
@@ -58,14 +64,32 @@ const reportError = async (report: ErrorReport): Promise<void> => {
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null, errorInfo: null };
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      isReloading: false,
+    };
   }
 
   static getDerivedStateFromError(error: Error): Partial<State> {
-    return { hasError: true, error };
+    // Optimistically suppress the error UI for chunk-load failures — they are
+    // recovered by a reload in componentDidCatch (or shown gracefully if the
+    // reload cap is reached).
+    return { hasError: true, error, isReloading: isChunkLoadError(error) };
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // A failed code-split chunk (stale deploy, network blip) is recoverable by
+    // reloading for a fresh index.html — do that before showing any error UI.
+    if (isChunkLoadError(error)) {
+      if (attemptChunkReload()) {
+        return; // page is about to reload
+      }
+      // Reload cap reached: fall through and show the graceful fallback.
+      this.setState({ isReloading: false });
+    }
+
     // Update state with error info
     this.setState({ errorInfo });
 
@@ -99,11 +123,22 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   handleReset = (): void => {
-    this.setState({ hasError: false, error: null, errorInfo: null });
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+      isReloading: false,
+    });
   };
 
   render(): ReactNode {
     if (this.state.hasError) {
+      // A reload is pending to recover from a chunk-load failure — render
+      // nothing rather than flashing the error screen.
+      if (this.state.isReloading) {
+        return null;
+      }
+
       if (this.props.fallback) {
         return this.props.fallback;
       }
@@ -117,8 +152,8 @@ export class ErrorBoundary extends Component<Props, State> {
               We encountered an unexpected error. Please try refreshing the page
               or going back to the home page.
             </p>
-            {/* Show error details for debugging - BIG AND OBVIOUS */}
-            {this.state.error && (
+            {/* Raw error/stack is dev-only — never shown to end users in prod */}
+            {import.meta.env.DEV && this.state.error && (
               <div style={{
                 marginTop: "30px",
                 padding: "20px",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,8 +5,34 @@ import { ThemeProvider } from "@/theme";
 import "./theme/theme.css";
 import { logger } from "@/utils/logger";
 import { initWebVitals } from "@/utils/performance";
+import {
+  isChunkLoadError,
+  attemptChunkReload,
+  resetChunkReloadCounter,
+} from "@/utils/chunkErrorRecovery";
 
 logger.debug("Index file is running");
+
+// Recover from transient/stale dynamic-import (chunk/CSS preload) failures by
+// reloading once for a fresh index.html, instead of letting React.lazy trip the
+// top-level error screen. Vite fires this event from its preload helper.
+window.addEventListener("vite:preloadError", (event) => {
+  // Suppress Vite's default rethrow; we recover by reloading instead.
+  event.preventDefault();
+  attemptChunkReload();
+});
+
+// Belt-and-braces: some chunk failures surface as unhandled promise rejections
+// (e.g. the module fetch itself) rather than a vite:preloadError event.
+window.addEventListener("unhandledrejection", (event) => {
+  if (isChunkLoadError(event.reason) && attemptChunkReload()) {
+    event.preventDefault();
+  }
+});
+
+// If the app is still alive after a few seconds the load succeeded — clear the
+// reload cap so a future deploy in the same session can self-heal again.
+window.setTimeout(resetChunkReloadCounter, 5000);
 
 // Initialize Core Web Vitals monitoring
 initWebVitals();

--- a/apps/web/src/utils/chunkErrorRecovery.ts
+++ b/apps/web/src/utils/chunkErrorRecovery.ts
@@ -1,0 +1,75 @@
+/**
+ * Recovery helpers for dynamic-import / CSS chunk-load failures.
+ *
+ * Vite code-splits routes into hashed chunks. A chunk can momentarily fail to
+ * load — a transient network blip, a CDN edge miss, or (most commonly) a client
+ * holding an old index.html across a deploy that has since rotated the asset
+ * hashes. React surfaces this as a thrown error from React.lazy, which would
+ * otherwise trip the top-level ErrorBoundary and show a scary debug screen on a
+ * public, investor-facing site.
+ *
+ * Reloading the page fetches a fresh index.html (and therefore the current
+ * chunk hashes), which resolves the overwhelming majority of these failures.
+ * We cap the number of automatic reloads per session so a genuinely missing
+ * asset can't trap the visitor in a reload loop.
+ */
+
+const RELOAD_COUNT_KEY = "chunk-reload-count";
+const MAX_AUTO_RELOADS = 2;
+
+/** Heuristic match for the various ways a failed chunk/CSS load surfaces. */
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  const err = error as { name?: string; message?: string };
+  const haystack = `${err.name ?? ""} ${err.message ?? ""}`;
+  return (
+    /Unable to preload CSS/i.test(haystack) ||
+    /Failed to fetch dynamically imported module/i.test(haystack) ||
+    /error loading dynamically imported module/i.test(haystack) ||
+    /Importing a module script failed/i.test(haystack) ||
+    /ChunkLoadError/i.test(haystack) ||
+    /Loading chunk \d+ failed/i.test(haystack) ||
+    /Loading CSS chunk/i.test(haystack)
+  );
+}
+
+function getReloadCount(): number {
+  try {
+    return Number(sessionStorage.getItem(RELOAD_COUNT_KEY) ?? "0") || 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Reload the page to recover from a chunk-load failure, unless we have already
+ * reloaded MAX_AUTO_RELOADS times this session. Returns true if a reload was
+ * triggered (the caller should stop rendering / bail out).
+ */
+export function attemptChunkReload(): boolean {
+  if (getReloadCount() >= MAX_AUTO_RELOADS) {
+    return false;
+  }
+  try {
+    sessionStorage.setItem(RELOAD_COUNT_KEY, String(getReloadCount() + 1));
+  } catch {
+    // sessionStorage unavailable (private mode, etc.) — reload once anyway.
+  }
+  window.location.reload();
+  return true;
+}
+
+/**
+ * Clear the reload counter once the app has loaded successfully, so a future
+ * deploy in the same session can recover again. Call after a short delay so a
+ * chunk error during initial load still counts against the cap.
+ */
+export function resetChunkReloadCounter(): void {
+  try {
+    sessionStorage.removeItem(RELOAD_COUNT_KEY);
+  } catch {
+    // ignore — nothing to reset
+  }
+}


### PR DESCRIPTION
## Why
A visitor hit a raw **"Oops! / DEBUG INFO (share this with developer)"** error screen on the live site at `/portfolio/airkey`:

> `Error: Unable to preload CSS for /assets/ProjectDetail-DcaeMC4r.css`

Diagnosis: the asset is actually **present and served 200** (`text/css`, 9778 bytes) and the live `index.html` references the exact `index-Bj1QSY6L.js` the browser loaded — so this is **not** a missing asset or stale-index problem. It's a **transient dynamic-import failure** (network blip / CDN edge miss / a tab held open across the recent deploy that rotated asset hashes). React surfaces it from `React.lazy` and the top-level `ErrorBoundary` then shows a developer debug screen to end users.

## What
- **`utils/chunkErrorRecovery.ts`** (new) — shared helper: `isChunkLoadError`, `attemptChunkReload` (session-capped at 2 reloads to avoid loops), `resetChunkReloadCounter`.
- **`main.tsx`** — listen for Vite's `vite:preloadError` (and chunk-shaped `unhandledrejection`s); `preventDefault()` and reload once for a fresh `index.html`. Reset the cap after a successful 5s load so a later deploy can self-heal again.
- **`ErrorBoundary.tsx`** — treat chunk-load errors as recoverable (reload instead of error screen), and render the raw error message + stack **only in dev** (`import.meta.env.DEV`). Production users see the friendly message + Go Home / Try Again only.

## Notes
- No behaviour change for genuine (non-chunk) errors except the debug stack is no longer dumped to end users in production.
- Reloads are capped per session; a genuinely-missing asset can't trap a visitor in a reload loop.
- Verified: changed files are type-clean (pre-existing repo `tsc` errors are all in unrelated theme/demo files) and ESLint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during app updates by automatically recovering from chunk-load failures, reducing instances where users encounter error screens during deployment transitions.
  * Enhanced error boundary to gracefully suppress debug information in production while retaining it during development.

* **New Features**
  * Added automatic recovery mechanism for transient chunk-load failures with intelligent retry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->