### PR TITLE
fix(web): Portfolio breadcrumb link + tame scroll-to-explore hint

### DIFF
--- a/apps/web/src/features/hero/components/Hero/Hero.tsx
+++ b/apps/web/src/features/hero/components/Hero/Hero.tsx
@@ -93,14 +93,12 @@ const Hero: FC<ExtendedHeroProps> = memo(
         const currentScrollPosition = window.scrollY;
         setScrollPosition(currentScrollPosition);
 
-        // Hide scroll indicator after scrolling, show return button instead
-        if (currentScrollPosition > 50) {
-          setShowScrollIndicator(false);
-          setShowReturnToStars(true);
-        } else {
-          setShowScrollIndicator(true);
-          setShowReturnToStars(false);
-        }
+        // The "Scroll to Explore" hint is only for the very top of the page —
+        // hide it as soon as the user scrolls at all (small threshold avoids
+        // sub-pixel flicker). Return-to-stars still waits until meaningfully
+        // scrolled away.
+        setShowScrollIndicator(currentScrollPosition <= 4);
+        setShowReturnToStars(currentScrollPosition > 50);
       };
 
       window.addEventListener("scroll", handleScroll);
@@ -337,7 +335,7 @@ const Hero: FC<ExtendedHeroProps> = memo(
             <motion.button
               className={styles.scrollIndicator}
               initial={{ opacity: 0, x: "-50%" }}
-              animate={{ opacity: 1, x: "-50%", y: [0, 10, 0] }}
+              animate={{ opacity: 1, x: "-50%", y: [0, 6, 0] }}
               exit={{ opacity: 0 }}
               transition={{
                 opacity: { duration: 0.5 },
@@ -350,8 +348,8 @@ const Hero: FC<ExtendedHeroProps> = memo(
               aria-label="Scroll to explore content"
             >
               <svg
-                width="18"
-                height="18"
+                width="14"
+                height="14"
                 viewBox="0 0 24 24"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"

--- a/apps/web/src/features/hero/components/Hero/hero.module.css
+++ b/apps/web/src/features/hero/components/Hero/hero.module.css
@@ -205,21 +205,23 @@
 
 .scrollIndicator {
   position: fixed; /* Changed from absolute to fixed for viewport positioning */
-  bottom: 2rem;
+  /* Hug the very bottom edge and stay compact so it overlaps the interactive
+     starfield (and the suns) as little as possible. */
+  bottom: 0.85rem;
   /* Center in viewport - matches zoom button centering logic */
   left: 50%;
   transform: translateX(-50%);
   width: fit-content; /* Allow the element to size to its content */
   z-index: 20;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.35rem;
   cursor: pointer; /* Ensure cursor shows it's clickable */
   transition: all 0.3s ease;
   background-color: rgba(147, 51, 234, 0.6); /* Purple color to match the theme */
-  padding: 0.5rem 1rem;
-  border-radius: 1.5rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 1rem;
   backdrop-filter: blur(4px);
   border: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow: 0 0 10px rgba(147, 51, 234, 0.3); /* Purple shadow for better visibility */
@@ -233,9 +235,9 @@
 }
 
 .scrollText {
-  font-size: 0.75rem;
+  font-size: 0.625rem;
   font-weight: 500;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: white;
 }

--- a/apps/web/src/features/portfolio/ProjectDetail.tsx
+++ b/apps/web/src/features/portfolio/ProjectDetail.tsx
@@ -161,7 +161,7 @@ export const ProjectDetail = (): React.ReactElement => {
                 Home
               </Link>
               <ChevronRight size={16} className={styles.breadcrumbSeparator} />
-              <Link to="/#portfolio" className={styles.breadcrumbLink}>
+              <Link to="/portfolio" className={styles.breadcrumbLink}>
                 Portfolio
               </Link>
               <ChevronRight size={16} className={styles.breadcrumbSeparator} />


### PR DESCRIPTION
Two small UX fixes you flagged.

## 1. Portfolio breadcrumb links incorrectly
On a project detail page (`/portfolio/:id`) the breadcrumb `Home › Portfolio › {project}` had **Portfolio** pointing at `/#portfolio` — but no `#portfolio` anchor exists anywhere, so it dumped you at the home page top. Now points at the real **`/portfolio`** route, consistent with the main nav (`constants/navigation.tsx`) and the not-found page's "Back to Portfolio". (Main nav itself was already correct.)

## 2. "Scroll to Explore" hint — timing + clickthrough
- **Timing:** it's a top-of-page hint but only hid after 50px of scroll. Now hides as soon as you scroll at all (4px threshold to avoid sub-pixel flicker). Return-to-stars still waits for 50px.
- **Clickthrough:** the hint (`z-index: 20`) sits over the starfield canvas (`z-index: 3`), so clicking a sun under it fired "scroll to focus-areas" instead of zooming. Kept it clickable (per your call) but **shrunk + lowered** it into a compact bottom-edge pill (row layout, smaller padding/font/chevron, `bottom: 0.85rem`) so it overlaps the suns — and steals their clicks — far less.

## Notes
- ESLint-clean on the changed TS files; CSS-only changes otherwise.
- Behaviour-only; no API/route changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)