### PR TITLE
fix(web): scroll hint via IntersectionObserver + icons for new projects

### DIFF
--- a/apps/web/src/features/hero/components/Hero/Hero.tsx
+++ b/apps/web/src/features/hero/components/Hero/Hero.tsx
@@ -44,6 +44,7 @@ const Hero: FC<ExtendedHeroProps> = memo(
       logger.debug(`[Home] Section "${id}" is now visible`);
     });
     const containerRef = useRef<HTMLDivElement>(null);
+    const topSentinelRef = useRef<HTMLDivElement>(null);
     const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
     const [isMouseNearBorder, setIsMouseNearBorder] = useState(false);
 
@@ -92,18 +93,31 @@ const Hero: FC<ExtendedHeroProps> = memo(
       const handleScroll = (): void => {
         const currentScrollPosition = window.scrollY;
         setScrollPosition(currentScrollPosition);
-
-        // The "Scroll to Explore" hint is only for the very top of the page —
-        // hide it as soon as the user scrolls at all (small threshold avoids
-        // sub-pixel flicker). Return-to-stars still waits until meaningfully
-        // scrolled away.
-        setShowScrollIndicator(currentScrollPosition <= 4);
+        // Return-to-stars appears once the user has scrolled meaningfully away.
         setShowReturnToStars(currentScrollPosition > 50);
       };
 
-      window.addEventListener("scroll", handleScroll);
+      window.addEventListener("scroll", handleScroll, { passive: true });
       handleScroll(); // Initial check
       return (): void => window.removeEventListener("scroll", handleScroll);
+    }, []);
+
+    // The "Scroll to Explore" hint belongs only at the very top of the page.
+    // Drive its visibility from an IntersectionObserver on a 1px sentinel at the
+    // top of the hero rather than window.scrollY — on this layout window.scrollY
+    // wasn't a reliable signal, which left the hint visible far down the page.
+    // The sentinel leaves the viewport the moment the user scrolls at all, and
+    // re-enters when they scroll back to the top.
+    useEffect(() => {
+      const sentinel = topSentinelRef.current;
+      if (!sentinel) return;
+
+      const observer = new IntersectionObserver(
+        ([entry]): void => setShowScrollIndicator(entry.isIntersecting),
+        { threshold: 0 },
+      );
+      observer.observe(sentinel);
+      return (): void => observer.disconnect();
     }, []);
 
     const getThemeStyles = (): {
@@ -144,6 +158,12 @@ const Hero: FC<ExtendedHeroProps> = memo(
           backgroundPosition: `center ${scrollPosition * 0.05}px`,
         }}
       >
+        {/* 1px sentinel at the very top — drives the scroll-hint visibility */}
+        <div
+          ref={topSentinelRef}
+          aria-hidden="true"
+          className={styles.scrollSentinel}
+        />
         <div
           className={
             isDarkMode ? styles.heroOverlayDark : styles.heroOverlayLight

--- a/apps/web/src/features/hero/components/Hero/hero.module.css
+++ b/apps/web/src/features/hero/components/Hero/hero.module.css
@@ -203,6 +203,14 @@
   transform: translateY(-2px);
 }
 
+/* 1px marker at the top of the hero; the scroll-to-explore hint is shown only
+   while this is in the viewport (i.e. the page is at the very top). */
+.scrollSentinel {
+  width: 100%;
+  height: 1px;
+  pointer-events: none;
+}
+
 .scrollIndicator {
   position: fixed; /* Changed from absolute to fixed for viewport positioning */
   /* Hug the very bottom edge and stay compact so it overlaps the interactive

--- a/apps/web/src/features/portfolio/ProjectDetail.tsx
+++ b/apps/web/src/features/portfolio/ProjectDetail.tsx
@@ -23,6 +23,10 @@ import {
   ChevronRight,
   Home,
   Bot,
+  Waypoints,
+  Receipt,
+  MessagesSquare,
+  Share2,
   X,
 } from "lucide-react";
 import { SEO } from "@/components/SEO";
@@ -48,6 +52,10 @@ const projectIcons: Record<string, React.ReactNode> = {
   autopr: <Bot size={48} />,
   "phoenixvc-website": <Globe size={48} />,
   "design-system": <Code size={48} />,
+  sluice: <Waypoints size={48} />,
+  docket: <Receipt size={48} />,
+  convolens: <MessagesSquare size={48} />,
+  omnipost: <Share2 size={48} />,
 };
 
 // Focus area icons (non-serializable, kept local)


### PR DESCRIPTION
Follow-ups to the live site.

## 1. "Scroll to Explore" hint shows at the wrong time
It was driven by `window.scrollY`, which on this layout isn't a reliable signal — the hint stayed visible far down the page (you reported it only disappearing around the last section). Now a 1px sentinel sits at the top of the hero and an **IntersectionObserver** toggles the hint: it hides the moment the top leaves the viewport (any scroll) and returns when you scroll back up — independent of the scroll mechanism.

## 2. New projects had no detail-page icon
Sluice/Docket/ConvoLens/OmniPost were falling back to the generic `Layers` icon. Gave each a fitting lucide icon: Sluice→Waypoints, Docket→Receipt, ConvoLens→MessagesSquare, OmniPost→Share2.

## Notes
- ESLint-clean; the IntersectionObserver code is type-clean. The new icons carry the same pre-existing `@types/react`-skew TS2786 type-noise as the 10 existing project icons (repo ships with this; build doesn't typecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added icon support for additional projects in the portfolio section.

* **Improvements**
  * Enhanced "Scroll to Explore" hint detection mechanism for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->