### PR TITLE
feat(web): bespoke per-project portfolio logos + single-source listing

### DIFF
--- a/apps/web/public/logos/airkey.svg
+++ b/apps/web/public/logos/airkey.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Airkey logo">
+  <defs>
+    <linearGradient id="airkey" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#e74c3c" />
+      <stop offset="1" stop-color="#c0392b" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#airkey)" />
+  <circle cx="25" cy="32" r="9" fill="none" stroke="#fff" stroke-width="3.4" />
+  <circle cx="25" cy="32" r="3" fill="#fff" />
+  <rect x="32" y="30.2" width="18" height="3.6" rx="1.8" fill="#fff" />
+  <rect x="42" y="32" width="3.4" height="6.5" rx="1.2" fill="#fff" />
+  <rect x="47" y="32" width="3.4" height="4.8" rx="1.2" fill="#fff" />
+  <g stroke="#fff" stroke-width="2.2" fill="none" stroke-linecap="round" opacity=".75">
+    <path d="M14 26a9 10 0 0 0 0 12" />
+    <path d="M10 22a15 17 0 0 0 0 20" opacity=".7" />
+  </g>
+</svg>

--- a/apps/web/public/logos/autopr.svg
+++ b/apps/web/public/logos/autopr.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="CodeFlow AI logo">
+  <defs>
+    <linearGradient id="autopr" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5dade2" />
+      <stop offset="1" stop-color="#2e86c1" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#autopr)" />
+  <g stroke="#fff" stroke-width="3" fill="none" stroke-linecap="round">
+    <line x1="22" y1="23.6" x2="22" y2="40.4" />
+    <path d="M22 31c7 0 10-3 15-6.5" />
+  </g>
+  <g fill="#fff">
+    <circle cx="22" cy="19" r="4.6" />
+    <circle cx="22" cy="45" r="4.6" />
+    <circle cx="40" cy="23.5" r="4.6" />
+  </g>
+  <path d="M45.5 40l1.2 3.1 3.1 1.2-3.1 1.2-1.2 3.1-1.2-3.1-3.1-1.2 3.1-1.2Z" fill="#fff" />
+</svg>

--- a/apps/web/public/logos/chaufher.svg
+++ b/apps/web/public/logos/chaufher.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Chaufher logo">
+  <defs>
+    <linearGradient id="chaufher" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2ecc71" />
+      <stop offset="1" stop-color="#239b56" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#chaufher)" />
+  <circle cx="32" cy="32" r="18" fill="none" stroke="#fff" stroke-width="3.4" />
+  <circle cx="32" cy="32" r="5" fill="#fff" />
+  <g stroke="#fff" stroke-width="3.2" stroke-linecap="round">
+    <line x1="32" y1="37" x2="32" y2="49" />
+    <line x1="27.7" y1="29.5" x2="18" y2="27" />
+    <line x1="36.3" y1="29.5" x2="46" y2="27" />
+  </g>
+</svg>

--- a/apps/web/public/logos/cognitivemesh.svg
+++ b/apps/web/public/logos/cognitivemesh.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Cognitive Mesh logo">
+  <defs>
+    <linearGradient id="cognitivemesh" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#3498db" />
+      <stop offset="1" stop-color="#2471a3" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#cognitivemesh)" />
+  <g stroke="#fff" stroke-width="1.2" opacity=".4">
+    <path d="M32 16 46 23 46 41 32 48 18 41 18 23Z" />
+  </g>
+  <g stroke="#fff" stroke-width="1.6" opacity=".85">
+    <line x1="32" y1="32" x2="32" y2="16" />
+    <line x1="32" y1="32" x2="46" y2="23" />
+    <line x1="32" y1="32" x2="46" y2="41" />
+    <line x1="32" y1="32" x2="32" y2="48" />
+    <line x1="32" y1="32" x2="18" y2="41" />
+    <line x1="32" y1="32" x2="18" y2="23" />
+  </g>
+  <g fill="#fff">
+    <circle cx="32" cy="32" r="3.6" />
+    <circle cx="32" cy="16" r="2.6" />
+    <circle cx="46" cy="23" r="2.6" />
+    <circle cx="46" cy="41" r="2.6" />
+    <circle cx="32" cy="48" r="2.6" />
+    <circle cx="18" cy="41" r="2.6" />
+    <circle cx="18" cy="23" r="2.6" />
+  </g>
+</svg>

--- a/apps/web/public/logos/convolens.svg
+++ b/apps/web/public/logos/convolens.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="ConvoLens logo">
+  <defs>
+    <linearGradient id="convolens" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6c5ce7" />
+      <stop offset="1" stop-color="#4834d4" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#convolens)" />
+  <line x1="38" y1="38" x2="49" y2="49" stroke="#fff" stroke-width="4.4" stroke-linecap="round" />
+  <circle cx="28" cy="28" r="14" fill="#fff" />
+  <path d="M20 23h16a2.6 2.6 0 0 1 2.6 2.6v6.4a2.6 2.6 0 0 1-2.6 2.6h-9.4l-4.4 3.6.5-3.6H20a2.6 2.6 0 0 1-2.6-2.6v-6.4A2.6 2.6 0 0 1 20 23Z" fill="#6c5ce7" />
+  <g fill="#fff">
+    <circle cx="23.5" cy="28.8" r="1.7" />
+    <circle cx="28" cy="28.8" r="1.7" />
+    <circle cx="32.5" cy="28.8" r="1.7" />
+  </g>
+</svg>

--- a/apps/web/public/logos/design-system.svg
+++ b/apps/web/public/logos/design-system.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Design System logo">
+  <defs>
+    <linearGradient id="design-system" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6b7280" />
+      <stop offset="1" stop-color="#4b5563" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#design-system)" />
+  <rect x="14" y="14" width="16" height="16" rx="3.5" fill="#fff" />
+  <circle cx="42" cy="22" r="8" fill="none" stroke="#fff" stroke-width="3" />
+  <rect x="14" y="35" width="16" height="15" rx="3.5" fill="none" stroke="#fff" stroke-width="3" />
+  <rect x="34" y="35" width="16" height="15" rx="3.5" fill="#fff" />
+</svg>

--- a/apps/web/public/logos/docket.svg
+++ b/apps/web/public/logos/docket.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Docket logo">
+  <defs>
+    <linearGradient id="docket" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5499c7" />
+      <stop offset="1" stop-color="#2e86c1" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#docket)" />
+  <path d="M20 14h24v36l-4-3-4 3-4-3-4 3-4-3-4 3Z" fill="#fff" opacity=".96" />
+  <line x1="25" y1="21" x2="39" y2="21" stroke="#5499c7" stroke-width="2" stroke-linecap="round" opacity=".55" />
+  <g fill="#5499c7">
+    <rect x="25" y="33" width="4" height="9" rx="1.2" />
+    <rect x="31" y="28" width="4" height="14" rx="1.2" />
+    <rect x="37" y="24" width="4" height="18" rx="1.2" />
+  </g>
+</svg>

--- a/apps/web/public/logos/hop.svg
+++ b/apps/web/public/logos/hop.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Hop logo">
+  <defs>
+    <linearGradient id="hop" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#27ae60" />
+      <stop offset="1" stop-color="#1e8449" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#hop)" />
+  <path d="M18 45Q32 14 46 45" stroke="#fff" stroke-width="2.6" fill="none" stroke-linecap="round" />
+  <circle cx="18" cy="45" r="4" fill="#fff" />
+  <circle cx="46" cy="45" r="4" fill="#fff" />
+  <g stroke="#fff" stroke-width="2.2" fill="none" stroke-linecap="round" opacity=".85">
+    <path d="M27 25a7 7 0 0 1 10 0" />
+    <path d="M23 21a13 13 0 0 1 18 0" opacity=".7" />
+  </g>
+  <circle cx="32" cy="28" r="2.4" fill="#fff" />
+</svg>

--- a/apps/web/public/logos/mystira.svg
+++ b/apps/web/public/logos/mystira.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Mystira logo">
+  <defs>
+    <linearGradient id="mystira" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#9b59b6" />
+      <stop offset="1" stop-color="#7d3c98" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#mystira)" />
+  <path d="M32 21c-5-3.4-12-3.4-17-1.3v25c5-2.1 12-2.1 17 1.3 5-3.4 12-3.4 17-1.3v-25c-5-2.1-12-2.1-17 1.3Z" fill="#fff" opacity=".96" />
+  <path d="M32 21v24.7" stroke="#7d3c98" stroke-width="2" stroke-linecap="round" />
+  <path d="M19 27h8M19 32h8M37 27h8M37 32h8" stroke="#9b59b6" stroke-width="1.6" stroke-linecap="round" opacity=".5" />
+  <path d="M46.5 11l1.4 3.6 3.6 1.4-3.6 1.4-1.4 3.6-1.4-3.6-3.6-1.4 3.6-1.4Z" fill="#fff" />
+</svg>

--- a/apps/web/public/logos/nexamesh.svg
+++ b/apps/web/public/logos/nexamesh.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Nexamesh logo">
+  <defs>
+    <linearGradient id="nexamesh" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#c0392b" />
+      <stop offset="1" stop-color="#922b21" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#nexamesh)" />
+  <path d="M32 13l16 6v13c0 9-7 15-16 18-9-3-16-9-16-18V19Z" fill="#fff" opacity=".96" />
+  <circle cx="32" cy="32" r="9" fill="none" stroke="#c0392b" stroke-width="1.8" />
+  <g stroke="#c0392b" stroke-width="1.8" stroke-linecap="round">
+    <line x1="32" y1="20" x2="32" y2="26" />
+    <line x1="32" y1="38" x2="32" y2="44" />
+    <line x1="20" y1="32" x2="26" y2="32" />
+    <line x1="38" y1="32" x2="44" y2="32" />
+  </g>
+  <circle cx="32" cy="32" r="2.6" fill="#c0392b" />
+</svg>

--- a/apps/web/public/logos/omnipost.svg
+++ b/apps/web/public/logos/omnipost.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="OmniPost logo">
+  <defs>
+    <linearGradient id="omnipost" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6b7280" />
+      <stop offset="1" stop-color="#4b5563" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#omnipost)" />
+  <g stroke="#fff" stroke-width="2.2" stroke-linecap="round" opacity=".8">
+    <line x1="32" y1="32" x2="32" y2="16" />
+    <line x1="32" y1="32" x2="47" y2="22" />
+    <line x1="32" y1="32" x2="49" y2="40" />
+    <line x1="32" y1="32" x2="40" y2="50" />
+    <line x1="32" y1="32" x2="20" y2="48" />
+    <line x1="32" y1="32" x2="15" y2="34" />
+    <line x1="32" y1="32" x2="19" y2="20" />
+  </g>
+  <g fill="#fff">
+    <circle cx="32" cy="16" r="3" />
+    <circle cx="47" cy="22" r="3" />
+    <circle cx="49" cy="40" r="3" />
+    <circle cx="40" cy="50" r="3" />
+    <circle cx="20" cy="48" r="3" />
+    <circle cx="15" cy="34" r="3" />
+    <circle cx="19" cy="20" r="3" />
+  </g>
+  <circle cx="32" cy="32" r="6" fill="#fff" />
+  <circle cx="32" cy="32" r="2.6" fill="#6b7280" />
+</svg>

--- a/apps/web/public/logos/phoenixvc-website.svg
+++ b/apps/web/public/logos/phoenixvc-website.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="PhoenixVC Website logo">
+  <defs>
+    <linearGradient id="phoenixvc-website" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6b7280" />
+      <stop offset="1" stop-color="#4b5563" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#phoenixvc-website)" />
+  <circle cx="32" cy="32" r="18" fill="none" stroke="#fff" stroke-width="3" />
+  <ellipse cx="32" cy="32" rx="8" ry="18" fill="none" stroke="#fff" stroke-width="2.4" />
+  <g stroke="#fff" stroke-width="2.4" fill="none" stroke-linecap="round">
+    <line x1="14" y1="32" x2="50" y2="32" />
+    <line x1="18" y1="23" x2="46" y2="23" />
+    <line x1="18" y1="41" x2="46" y2="41" />
+  </g>
+</svg>

--- a/apps/web/public/logos/sluice.svg
+++ b/apps/web/public/logos/sluice.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="Sluice logo">
+  <defs>
+    <linearGradient id="sluice" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2980b9" />
+      <stop offset="1" stop-color="#1f618d" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#sluice)" />
+  <g stroke="#fff" stroke-width="2.4" fill="none" stroke-linecap="round">
+    <path d="M18 20c8 0 8 12 13 12" />
+    <path d="M18 32h13" />
+    <path d="M18 44c8 0 8-12 13-12" />
+  </g>
+  <g fill="#fff">
+    <circle cx="15" cy="20" r="3.2" />
+    <circle cx="15" cy="32" r="3.2" />
+    <circle cx="15" cy="44" r="3.2" />
+  </g>
+  <circle cx="34" cy="32" r="5.6" fill="#fff" />
+  <g stroke="#fff" stroke-width="2.6" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="39.6" y1="32" x2="50" y2="32" />
+    <path d="M45 27l5 5-5 5" />
+  </g>
+</svg>

--- a/apps/web/public/logos/veritasvault.svg
+++ b/apps/web/public/logos/veritasvault.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="VeritasVault logo">
+  <defs>
+    <linearGradient id="veritasvault" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f39c12" />
+      <stop offset="1" stop-color="#d68910" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#veritasvault)" />
+  <rect x="14" y="15" width="36" height="34" rx="5" fill="#fff" opacity=".96" />
+  <circle cx="32" cy="32" r="11" fill="none" stroke="#f39c12" stroke-width="2.4" />
+  <g stroke="#f39c12" stroke-width="2.4" stroke-linecap="round">
+    <line x1="32" y1="20" x2="32" y2="25" />
+    <line x1="32" y1="39" x2="32" y2="44" />
+    <line x1="20" y1="32" x2="25" y2="32" />
+    <line x1="39" y1="32" x2="44" y2="32" />
+  </g>
+  <circle cx="32" cy="32" r="3" fill="#f39c12" />
+  <g fill="#f39c12">
+    <circle cx="19" cy="20" r="1.6" />
+    <circle cx="45" cy="20" r="1.6" />
+    <circle cx="19" cy="44" r="1.6" />
+    <circle cx="45" cy="44" r="1.6" />
+  </g>
+</svg>

--- a/apps/web/src/constants/portfolioData.ts
+++ b/apps/web/src/constants/portfolioData.ts
@@ -48,6 +48,10 @@ export interface PortfolioProject {
   expertise?: string;
   projects?: string[];
   bio?: string;
+  /** Short subtitle shown on the /portfolio listing card (falls back to position). */
+  tagline?: string;
+  /** Whether the project appears on the public /portfolio listing. Defaults to true. */
+  listed?: boolean;
   title: string;
   status: ProjectStatus;
   relatedProjects: string[];
@@ -142,7 +146,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Interactive Storytelling",
     mass: 500,
     color: "#9b59b6", // Purple variant - AI & ML focus area (slightly different from pure blue)
-    image: "/themes/mystira-icon.svg",
+    image: "/logos/mystira.svg",
+    tagline: "Interactive storytelling adventures for children and families",
     fullName: "Mystira",
     speed: 0.000025,
     title: "Interactive Storytelling Platform (Alpha)",
@@ -164,7 +169,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "AI Framework",
     mass: 150,
     color: "#3498db", // Blue - AI & ML focus area
-    image: "/themes/cognitivemesh-icon.svg",
+    image: "/logos/cognitivemesh.svg",
+    tagline: "Enterprise-grade AI transformation framework",
     fullName: "Cognitive Mesh",
     speed: 0.000022,
     title: "Enterprise AI Transformation Framework (Pre-Alpha)",
@@ -192,7 +198,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Counter-UAS Platform",
     mass: 200,
     color: "#c0392b", // Darker red variant - Defense & Security focus area
-    image: "/themes/rooivalk-icon.svg", // TODO: replace with nexamesh-branded icon
+    image: "/logos/nexamesh.svg",
+    tagline: "AI-powered counter-UAS defense platform",
     fullName: "Nexamesh",
     speed: 0.00002,
     title: "AI-Powered Counter-UAS Defense Platform (Pre-Alpha)",
@@ -214,7 +221,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Access Management",
     mass: 150,
     color: "#e74c3c", // Red - Defense & Security focus area
-    image: "/themes/airkey-icon.svg",
+    image: "/logos/airkey.svg",
+    tagline: "Digital access management solutions",
     fullName: "Airkey Ltd",
     speed: 0.000019,
     title: "Digital Access Management (Seed)",
@@ -238,7 +246,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "DeFi Platform",
     mass: 80,
     color: "#f39c12", // Orange - Fintech & Blockchain focus area
-    image: "/themes/veritasvault-icon.svg",
+    image: "/logos/veritasvault.svg",
+    tagline: "DeFi staking and treasury-backed rewards platform",
     fullName: "VeritasVault",
     speed: 0.00002,
     title: "DeFi Staking Platform (Pre-Alpha)",
@@ -262,7 +271,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Connectivity Tech",
     mass: 150,
     color: "#27ae60", // Darker green variant - Mobility & Transportation focus area
-    image: "/themes/hop-icon.svg",
+    image: "/logos/hop.svg",
+    tagline: "Innovative connectivity technology",
     fullName: "Hop Pty Ltd",
     speed: 0.000017,
     title: "Innovative Connectivity Technology (Seed)",
@@ -284,7 +294,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Women's Ridehail",
     mass: 180,
     color: "#2ecc71", // Green - Mobility & Transportation focus area
-    image: "/themes/chaufher-icon.svg",
+    image: "/logos/chaufher.svg",
+    tagline: "Women-focused ridehail service",
     fullName: "Chaufher Pty Ltd",
     speed: 0.000016,
     title: "Women-Focused Ridehail Service (Seed)",
@@ -308,7 +319,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "PR Automation",
     mass: 180,
     color: "#5dade2", // Lighter blue variant - AI & ML focus area
-    image: "/themes/codeflow-icon.svg",
+    image: "/logos/autopr.svg",
+    tagline: "AI-powered GitHub PR automation and issue management",
     fullName: "CodeFlow AI",
     speed: 0.000021,
     title: "AI-Powered PR Automation Platform (Pre-Alpha)",
@@ -330,6 +342,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "AI Gateway",
     mass: 120,
     color: "#2980b9", // Darker blue variant - AI & ML focus area
+    image: "/logos/sluice.svg",
+    tagline: "OpenAI-compatible AI gateway",
     fullName: "Sluice",
     speed: 0.00002,
     title: "OpenAI-Compatible AI Gateway (Pre-Alpha)",
@@ -351,6 +365,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "LLM Cost Ops",
     mass: 110,
     color: "#5499c7", // Blue variant - AI & ML focus area
+    image: "/logos/docket.svg",
+    tagline: "LLM cost-operations platform",
     fullName: "Docket",
     speed: 0.000019,
     title: "LLM Cost Operations Platform (Pre-Alpha)",
@@ -372,6 +388,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Conversation AI",
     mass: 120,
     color: "#6c5ce7", // Purple-blue variant - AI & ML focus area
+    image: "/logos/convolens.svg",
+    tagline: "AI conversation analyzer",
     fullName: "ConvoLens",
     speed: 0.000018,
     title: "AI Conversation Analyzer (Pre-Alpha)",
@@ -395,6 +413,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Content Distribution",
     mass: 100,
     color: "#6b7280",
+    image: "/logos/omnipost.svg",
+    tagline: "Multi-channel content distribution",
     fullName: "OmniPost",
     speed: 0.000017,
     title: "Multi-Channel Content Distribution (Pre-Alpha)",
@@ -416,7 +436,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Corporate Website",
     mass: 100,
     color: "#6b7280",
-    image: "/themes/phoenixvc-website-icon.svg",
+    image: "/logos/phoenixvc-website.svg",
+    listed: false,
     fullName: "PhoenixVC Website",
     speed: 0.000015,
     title: "Corporate Website",
@@ -438,7 +459,8 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
     position: "Component Library",
     mass: 80,
     color: "#6b7280",
-    image: "/themes/design-system-icon.svg",
+    image: "/logos/design-system.svg",
+    listed: false,
     fullName: "Phoenix Design System",
     speed: 0.000018,
     title: "Component Library",

--- a/apps/web/src/features/portfolio/Portfolio.module.css
+++ b/apps/web/src/features/portfolio/Portfolio.module.css
@@ -327,6 +327,14 @@
   align-items: center;
   justify-content: center;
   color: var(--portfolio-primary);
+  overflow: hidden;
+}
+
+/* Brand logo (self-contained gradient tile) fills the icon slot. */
+.projectIconImage {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .statusBadge {

--- a/apps/web/src/features/portfolio/ProjectDetail.tsx
+++ b/apps/web/src/features/portfolio/ProjectDetail.tsx
@@ -10,23 +10,13 @@ import {
   Calendar,
   Target,
   Layers,
-  Users,
   Zap,
-  BookOpen,
   Shield,
-  Network,
-  Key,
   Car,
   Vault,
   Code,
-  Globe,
   ChevronRight,
   Home,
-  Bot,
-  Waypoints,
-  Receipt,
-  MessagesSquare,
-  Share2,
   X,
 } from "lucide-react";
 import { SEO } from "@/components/SEO";
@@ -38,25 +28,8 @@ import {
   type PortfolioProject as _PortfolioProject,
   type FocusAreaId,
 } from "@/constants/portfolioData";
+import { getProjectIcon } from "./projectIcons";
 import styles from "./ProjectDetail.module.css";
-
-// Icon mapping for projects - includes all projects
-const projectIcons: Record<string, React.ReactNode> = {
-  mystira: <BookOpen size={48} />,
-  nexamesh: <Shield size={48} />,
-  cognitivemesh: <Network size={48} />,
-  airkey: <Key size={48} />,
-  hop: <Car size={48} />,
-  chaufher: <Users size={48} />,
-  veritasvault: <Vault size={48} />,
-  autopr: <Bot size={48} />,
-  "phoenixvc-website": <Globe size={48} />,
-  "design-system": <Code size={48} />,
-  sluice: <Waypoints size={48} />,
-  docket: <Receipt size={48} />,
-  convolens: <MessagesSquare size={48} />,
-  omnipost: <Share2 size={48} />,
-};
 
 // Focus area icons (non-serializable, kept local)
 const focusAreaIcons: Record<FocusAreaId, React.ReactNode> = {
@@ -127,7 +100,7 @@ export const ProjectDetail = (): React.ReactElement => {
   const status = STATUS_CONFIG[project.status] || STATUS_CONFIG.active;
   const focusAreaConfig = FOCUS_AREA_CONFIG[project.focusArea];
   const focusAreaIcon = focusAreaIcons[project.focusArea];
-  const icon = projectIcons[project.id] || <Layers size={48} />;
+  const icon = getProjectIcon(project.id, 48);
   const skills = Array.isArray(project.skills) ? project.skills : [];
 
   return (
@@ -192,7 +165,11 @@ export const ProjectDetail = (): React.ReactElement => {
               <div className={styles.heroContent}>
                 <div
                   className={styles.heroIcon}
-                  style={{ backgroundColor: project.color || "#9333ea" }}
+                  style={{
+                    backgroundColor: project.image
+                      ? "transparent"
+                      : project.color || "#9333ea",
+                  }}
                 >
                   {project.image ? (
                     <img
@@ -376,9 +353,7 @@ export const ProjectDetail = (): React.ReactElement => {
                   {relatedProjects.map((related) => {
                     const relatedStatus =
                       STATUS_CONFIG[related.status] || STATUS_CONFIG.active;
-                    const relatedIcon = projectIcons[related.id] || (
-                      <Layers size={24} />
-                    );
+                    const relatedIcon = getProjectIcon(related.id, 24);
                     return (
                       <Link
                         key={related.id}
@@ -388,7 +363,9 @@ export const ProjectDetail = (): React.ReactElement => {
                         <div
                           className={styles.relatedIcon}
                           style={{
-                            backgroundColor: related.color || "#9333ea",
+                            backgroundColor: related.image
+                              ? "transparent"
+                              : related.color || "#9333ea",
                           }}
                         >
                           {related.image ? (

--- a/apps/web/src/features/portfolio/index.tsx
+++ b/apps/web/src/features/portfolio/index.tsx
@@ -7,252 +7,66 @@ import {
   ExternalLink,
   Github,
   Cpu,
-  Network,
-  BookOpen,
-  Shield,
   FileText,
-  Key,
-  Car,
-  Users,
-  Vault,
   Eye,
   EyeOff,
   ArrowRight,
-  Bot,
-  Waypoints,
-  Receipt,
-  MessagesSquare,
-  Share2,
   Filter,
   X,
 } from "lucide-react";
 import { SEO } from "@/components/SEO";
+import {
+  PORTFOLIO_PROJECTS,
+  STATUS_CONFIG,
+  FOCUS_AREA_CONFIG,
+  type PortfolioProject,
+  type ProjectStatus,
+  type FocusAreaId,
+} from "@/constants/portfolioData";
+import { getProjectIcon } from "./projectIcons";
 import styles from "./Portfolio.module.css";
 
+// View model for a listing card. Derived from the single source of truth
+// (PORTFOLIO_PROJECTS) so the listing can no longer drift from the starfield
+// and detail page — that drift previously broke the Rooivalk → Nexamesh link.
 interface Project {
   id: string;
   name: string;
   description: string;
   longDescription: string;
-  icon: React.ReactNode;
+  image?: string;
   website?: string;
   github?: string;
   docs?: string;
-  status:
-    | "live"
-    | "development"
-    | "beta"
-    | "alpha"
-    | "pre-alpha"
-    | "seed"
-    | "early-stage"
-    | "growth";
+  status: ProjectStatus;
   tags: string[];
-  focusArea:
-    | "ai-ml"
-    | "fintech-blockchain"
-    | "defense-security"
-    | "mobility-transportation"
-    | "infrastructure";
+  focusArea: FocusAreaId;
 }
 
-const projects: Project[] = [
-  {
-    id: "mystira",
-    name: "Mystira",
-    description:
-      "Interactive storytelling adventures for children and families",
-    longDescription:
-      "Mystira brings the wonder of storytelling to life for children, parents, and group leaders alike. It transforms shared playtime into immersive, interactive adventures filled with imagination, cooperation, and creativity. Each Mystira story is grounded in child development research, fostering emotional growth, problem-solving skills, and meaningful connections.",
-    icon: <BookOpen size={32} />,
-    website: "https://mystira.app",
-    status: "alpha",
-    tags: ["Storytelling", "Children", "Interactive", "Education"],
-    focusArea: "ai-ml",
-  },
-  {
-    id: "autopr",
-    name: "CodeFlow AI",
-    description: "AI-powered GitHub PR automation and issue management",
-    longDescription:
-      "CodeFlow AI is a comprehensive AI-powered automation platform that transforms GitHub pull request workflows through intelligent analysis, issue creation, and multi-agent collaboration. Features CodeRabbit, GitHub Copilot integration, platform detection for 25+ development platforms, and supports Linear, Slack, and other integrations.",
-    icon: <Bot size={32} />,
-    website: "https://autopr.io",
-    github: "https://github.com/JustAGhosT/autopr-engine",
-    status: "pre-alpha",
-    tags: ["AI", "Automation", "GitHub", "DevOps", "Python"],
-    focusArea: "ai-ml",
-  },
-  {
-    id: "nexamesh",
-    name: "Nexamesh",
-    description: "AI-powered counter-UAS defense platform",
-    longDescription:
-      "Nexamesh (formerly Phoenix Rooivalk) is a sophisticated counter-UAS defense platform that leverages advanced AI and machine learning for real-time drone detection, classification, and neutralization, providing comprehensive airspace protection with automated threat assessment and response capabilities.",
-    icon: <Shield size={32} />,
-    github: "https://github.com/Nexamesh/nexamesh-core",
-    status: "pre-alpha",
-    tags: ["Counter-UAS", "AI", "Defense", "Security"],
-    focusArea: "defense-security",
-  },
-  {
-    id: "cognitivemesh",
-    name: "Cognitive Mesh",
-    description: "Enterprise-grade AI transformation framework",
-    longDescription:
-      "Cognitive Mesh is an enterprise-grade AI transformation framework designed to orchestrate multi-agent cognitive systems with institutional-grade security and compliance controls. It features a five-layer hexagonal architecture enabling organizations to build, deploy, and manage advanced AI capabilities with comprehensive governance, NIST AI Risk Management Framework compliance, and Zero-Trust security architecture.",
-    icon: <Network size={32} />,
-    github: "https://github.com/justaghost/cognitive-mesh",
-    status: "pre-alpha",
-    tags: [
-      "Multi-Agent",
-      "Enterprise",
-      "Security",
-      "Governance",
-      "Azure",
-      ".NET",
-    ],
-    focusArea: "ai-ml",
-  },
-  {
-    id: "airkey",
-    name: "Airkey",
-    description: "Digital access management solutions",
-    longDescription:
-      "Airkey Ltd provides innovative digital access management solutions that enable secure, keyless entry systems for various real-world assets. Using advanced cryptography and mobile technology, Airkey transforms how organizations manage physical access control.",
-    icon: <Key size={32} />,
-    status: "seed",
-    tags: ["Access Control", "Security", "IoT", "Mobile"],
-    focusArea: "defense-security",
-  },
-  {
-    id: "hop",
-    name: "Hop",
-    description: "Innovative connectivity technology",
-    longDescription:
-      "Hop (Pty) Ltd is revolutionizing urban mobility with innovative connectivity solutions. Their cutting edge platform and hardware connects commuters with high-speed internet.",
-    icon: <Car size={32} />,
-    status: "seed",
-    tags: ["Connectivity", "Mobility", "Hardware", "Internet"],
-    focusArea: "mobility-transportation",
-  },
-  {
-    id: "chaufher",
-    name: "Chaufher",
-    description: "Women-focused ridehail service",
-    longDescription:
-      "Chaufher (Pty) Ltd is a women-focused ridehail service designed to provide safe, reliable rides for women, by women. The platform prioritizes passenger safety with vetted drivers and specialized features tailored to women's transportation needs.",
-    icon: <Users size={32} />,
-    status: "seed",
-    tags: ["Transportation", "Safety", "Women-Focused", "Ride-Sharing"],
-    focusArea: "mobility-transportation",
-  },
-  {
-    id: "veritasvault",
-    name: "VeritasVault",
-    description: "DeFi staking and treasury-backed rewards platform",
-    longDescription:
-      "VeritasVault is a decentralized finance platform offering transparent, treasury-backed staking rewards with auto-compounding yields. The platform enables users to earn real yield through depositing, staking, and voting mechanisms with no lock-ups and instant withdrawals.",
-    icon: <Vault size={32} />,
-    website: "https://veritasvault.net",
-    github: "https://github.com/justAGhosT/vv",
-    status: "pre-alpha",
-    tags: ["DeFi", "Blockchain", "Staking", "Crypto", "Web3"],
-    focusArea: "fintech-blockchain",
-  },
-  {
-    id: "sluice",
-    name: "Sluice",
-    description: "OpenAI-compatible AI gateway",
-    longDescription:
-      "Sluice is an OpenAI-compatible AI gateway running on Azure Container Apps. Built on LiteLLM, it gives teams a single endpoint with model routing, provider abstraction, and cost controls across multiple LLM backends.",
-    icon: <Waypoints size={32} />,
-    github: "https://github.com/phoenixvc/sluice",
-    status: "pre-alpha",
-    tags: ["AI", "Gateway", "LiteLLM", "Azure"],
-    focusArea: "ai-ml",
-  },
-  {
-    id: "docket",
-    name: "Docket",
-    description: "LLM cost-operations platform",
-    longDescription:
-      "Docket is an AI cost-operations platform that tracks LLM spend, usage analytics, and cost optimisation across teams and providers, turning opaque token bills into actionable, per-project insight.",
-    icon: <Receipt size={32} />,
-    status: "pre-alpha",
-    tags: ["AI", "Cost Ops", "Analytics", "FinOps"],
-    focusArea: "ai-ml",
-  },
-  {
-    id: "convolens",
-    name: "ConvoLens",
-    description: "AI conversation analyzer",
-    longDescription:
-      "ConvoLens is an AI-powered conversation analyzer for WhatsApp. Upload a chat export to get summaries, sentiment, and insight into group and one-on-one conversations.",
-    icon: <MessagesSquare size={32} />,
-    website: "https://v0-whatsapp-conversation-summarizer.vercel.app",
-    status: "pre-alpha",
-    tags: ["AI", "NLP", "Analytics", "Summarization"],
-    focusArea: "ai-ml",
-  },
-  {
-    id: "omnipost",
-    name: "OmniPost",
-    description: "Multi-channel content distribution",
-    longDescription:
-      "OmniPost is a multi-channel content distribution tool for publishing and syndicating content across social and web channels from a single source.",
-    icon: <Share2 size={32} />,
-    github: "https://github.com/neuralliquid/omnipost",
-    status: "pre-alpha",
-    tags: ["Content", "Distribution", "Automation"],
-    focusArea: "infrastructure",
-  },
-];
-
-const statusColors: Record<
-  Project["status"],
-  { bg: string; text: string; label: string }
-> = {
-  live: { bg: "rgba(76, 175, 80, 0.2)", text: "#4caf50", label: "Live" },
-  beta: { bg: "rgba(255, 152, 0, 0.2)", text: "#ff9800", label: "Beta" },
-  alpha: {
-    bg: "rgba(156, 39, 176, 0.2)",
-    text: "#9c27b0",
-    label: "Alpha / Pre-Seed",
-  },
-  "pre-alpha": {
-    bg: "rgba(121, 85, 72, 0.2)",
-    text: "#795548",
-    label: "Angel / Pre-Seed",
-  },
-  seed: { bg: "rgba(46, 204, 113, 0.2)", text: "#27ae60", label: "Seed" },
-  "early-stage": {
-    bg: "rgba(230, 126, 34, 0.2)",
-    text: "#e67e22",
-    label: "Early Stage",
-  },
-  growth: {
-    bg: "rgba(231, 76, 60, 0.2)",
-    text: "#e74c3c",
-    label: "Growth Stage",
-  },
-  development: {
-    bg: "rgba(33, 150, 243, 0.2)",
-    text: "#2196f3",
-    label: "In Development",
-  },
+// Map a canonical PortfolioProject onto the listing card shape. Links are
+// derived from the single `product` field (GitHub vs. website) exactly like
+// the project detail page does, so the two views always agree.
+const toCardProject = (p: PortfolioProject): Project => {
+  const product = p.product?.trim() ?? "";
+  const isGithub = product.includes("github");
+  const tags = Array.isArray(p.skills) ? p.skills : p.skills ? [p.skills] : [];
+  return {
+    id: p.id,
+    name: p.name,
+    description: p.tagline ?? p.position ?? "",
+    longDescription: p.bio ?? "",
+    image: p.image,
+    website: product && !isGithub ? product : undefined,
+    github: product && isGithub ? product : undefined,
+    status: p.status,
+    tags,
+    focusArea: p.focusArea,
+  };
 };
 
-const focusAreaConfig: Record<
-  Project["focusArea"],
-  { label: string; color: string }
-> = {
-  "ai-ml": { label: "AI & ML", color: "#3498db" },
-  "fintech-blockchain": { label: "Fintech", color: "#f39c12" },
-  "defense-security": { label: "Defense", color: "#e74c3c" },
-  "mobility-transportation": { label: "Mobility", color: "#2ecc71" },
-  infrastructure: { label: "Infrastructure", color: "#6b7280" },
-};
+const projects: Project[] = PORTFOLIO_PROJECTS.filter(
+  (p) => p.listed !== false,
+).map(toCardProject);
 
 const animations = {
   container: {
@@ -293,11 +107,11 @@ export const Portfolio = (): React.ReactElement => {
   const { themeMode } = useTheme();
   const isDarkMode = themeMode === "dark";
   const [showComingSoon, setShowComingSoon] = useState(true);
-  const [selectedStatus, setSelectedStatus] = useState<
-    Project["status"] | "all"
-  >("all");
+  const [selectedStatus, setSelectedStatus] = useState<ProjectStatus | "all">(
+    "all",
+  );
   const [selectedFocusArea, setSelectedFocusArea] = useState<
-    Project["focusArea"] | "all"
+    FocusAreaId | "all"
   >("all");
   const navigate = useNavigate();
 
@@ -425,17 +239,19 @@ export const Portfolio = (): React.ReactElement => {
                       onClick={() => setSelectedFocusArea(area)}
                       style={{
                         ...(selectedFocusArea === area && {
-                          backgroundColor: `${focusAreaConfig[area].color}20`,
-                          borderColor: focusAreaConfig[area].color,
-                          color: focusAreaConfig[area].color,
+                          backgroundColor: `${FOCUS_AREA_CONFIG[area].color}20`,
+                          borderColor: FOCUS_AREA_CONFIG[area].color,
+                          color: FOCUS_AREA_CONFIG[area].color,
                         }),
                       }}
                     >
                       <span
                         className={styles.pillDot}
-                        style={{ backgroundColor: focusAreaConfig[area].color }}
+                        style={{
+                          backgroundColor: FOCUS_AREA_CONFIG[area].color,
+                        }}
                       />
-                      {focusAreaConfig[area].label}
+                      {FOCUS_AREA_CONFIG[area].label}
                     </button>
                   ))}
                 </div>
@@ -458,13 +274,13 @@ export const Portfolio = (): React.ReactElement => {
                       onClick={() => setSelectedStatus(status)}
                       style={{
                         ...(selectedStatus === status && {
-                          backgroundColor: statusColors[status].bg,
-                          borderColor: statusColors[status].text,
-                          color: statusColors[status].text,
+                          backgroundColor: STATUS_CONFIG[status].bg,
+                          borderColor: STATUS_CONFIG[status].text,
+                          color: STATUS_CONFIG[status].text,
                         }),
                       }}
                     >
-                      {statusColors[status].label}
+                      {STATUS_CONFIG[status].label}
                     </button>
                   ))}
                 </div>
@@ -522,15 +338,32 @@ export const Portfolio = (): React.ReactElement => {
                 >
                   <div className={styles.cardContent}>
                     <div className={styles.cardHeader}>
-                      <div className={styles.projectIcon}>{project.icon}</div>
+                      <div
+                        className={styles.projectIcon}
+                        style={
+                          project.image
+                            ? { background: "transparent" }
+                            : undefined
+                        }
+                      >
+                        {project.image ? (
+                          <img
+                            src={project.image}
+                            alt=""
+                            className={styles.projectIconImage}
+                          />
+                        ) : (
+                          getProjectIcon(project.id, 32)
+                        )}
+                      </div>
                       <div
                         className={styles.statusBadge}
                         style={{
-                          backgroundColor: statusColors[project.status].bg,
-                          color: statusColors[project.status].text,
+                          backgroundColor: STATUS_CONFIG[project.status].bg,
+                          color: STATUS_CONFIG[project.status].text,
                         }}
                       >
-                        {statusColors[project.status].label}
+                        {STATUS_CONFIG[project.status].label}
                       </div>
                     </div>
 

--- a/apps/web/src/features/portfolio/projectIcons.tsx
+++ b/apps/web/src/features/portfolio/projectIcons.tsx
@@ -1,0 +1,49 @@
+// /features/portfolio/projectIcons.tsx
+// Shared lucide fallback icons, keyed by project id.
+//
+// These are only used when a project has no `image` logo (every project
+// currently ships a brand SVG under /logos/<id>.svg) and as the placeholder
+// while that image loads. Keeping a single map here stops the /portfolio
+// listing and the project detail page from drifting apart — that dual-source
+// drift is what previously broke the Rooivalk → Nexamesh link.
+import React from "react";
+import {
+  BookOpen,
+  Network,
+  Shield,
+  Key,
+  Vault,
+  Car,
+  Users,
+  Bot,
+  Waypoints,
+  Receipt,
+  MessagesSquare,
+  Share2,
+  Globe,
+  Code,
+  Layers,
+} from "lucide-react";
+
+const ICONS: Record<string, React.ComponentType<{ size?: number }>> = {
+  mystira: BookOpen,
+  cognitivemesh: Network,
+  nexamesh: Shield,
+  airkey: Key,
+  veritasvault: Vault,
+  hop: Car,
+  chaufher: Users,
+  autopr: Bot,
+  sluice: Waypoints,
+  docket: Receipt,
+  convolens: MessagesSquare,
+  omnipost: Share2,
+  "phoenixvc-website": Globe,
+  "design-system": Code,
+};
+
+/** Returns the lucide fallback icon for a project id, sized as requested. */
+export function getProjectIcon(id: string, size = 32): React.ReactElement {
+  const Icon = ICONS[id] ?? Layers;
+  return <Icon size={size} />;
+}


### PR DESCRIPTION
## Portfolio logo pass + single-source consolidation

Investor-facing — **please review before merging; not auto-merged.**

### 1. Bespoke per-project logos (14)
A cohesive set under `apps/web/public/logos/<id>.svg`. Each is a self-contained rounded **gradient tile + white glyph** in the project's brand colour, so the same mark renders correctly in all three contexts — the starfield "sun" (circular-clipped), the project-detail hero, and the listing card. The detail/related/listing tiles use the existing `image ? transparent` pattern so the SVG provides its own background (no double-tile).

- Replaces the ad-hoc `/themes/*-icon.svg` set.
- **Nexamesh** gets its own shield+crosshair mark (was borrowing `rooivalk-icon.svg`).
- Fills the four projects that had **no** logo: **Sluice, Docket, ConvoLens, OmniPost**.
- Glyphs: Mystira=book+sparkle · CognitiveMesh=neural mesh · Nexamesh=shield+crosshair · Airkey=key+signal · VeritasVault=vault dial · Hop=hop arc+waves · Chaufher=steering wheel · CodeFlow=git branch+sparkle · Sluice=gateway/route · Docket=receipt+bars · ConvoLens=chat-in-lens · OmniPost=broadcast hub · PhoenixVC Website=globe · Design System=component blocks.

### 2. Kills the dual-array drift
The `/portfolio` listing had its **own** inline `projects` array, separate from `PORTFOLIO_PROJECTS` (the source the starfield + detail page use). They drifted — that's what broke the listing→detail link on the Rooivalk→Nexamesh rebrand. Now:

- The listing **derives from `PORTFOLIO_PROJECTS`**; the inline array is gone.
- Lucide fallback icons extracted to a shared `projectIcons.tsx` used by both the listing and the detail page.

### Consolidation decisions to sanity-check
- **`listed` flag (new):** `phoenixvc-website` and `design-system` are marked `listed: false`, so the public listing still shows the same **12** projects as before (these two internal infra items remain on the starfield only).
- **Links derive from the single `product` field** (GitHub vs. website), exactly like the detail page. Effect: projects that previously had *both* a website and a GitHub button on the listing now show one, matching the detail page — **VeritasVault** → website; **CodeFlow** → the `codeflow-engine` GitHub (the old listing's `autopr.io` / `autopr-engine` links were stale).
- **Copy:** card subtitle from a new `tagline` (ported verbatim from the old listing descriptions); paragraph from the existing `bio`.

### Verification
- `vite build` green; root `eslint` clean (0 errors).
- Screenshotted live: `/portfolio` (renders "12 of 12"), `/portfolio/sluice`, `/portfolio/nexamesh` — logos render in cards + heroes, links correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio projects now include custom taglines to provide better descriptions and context for each initiative.

* **Style**
  * Enhanced project icon display with improved image sizing and aspect ratio handling.
  * Refined visual presentation of portfolio entries with reorganization and selective unlisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->