### PR TITLE
fix(web): keep starfield centred through zoom-out

### DIFF
--- a/apps/web/src/features/layout/components/Starfield/hooks/animation/animate.ts
+++ b/apps/web/src/features/layout/components/Starfield/hooks/animation/animate.ts
@@ -34,6 +34,7 @@ import {
   STAR_RENDERING_CONFIG,
   ANIMATION_TIMING_CONFIG,
 } from "../../renderingConfig";
+import { CAMERA_CONFIG } from "../../physicsConfig";
 // Import modular rendering functions
 import { drawMouseEffects } from "./mouseEffects";
 import {
@@ -191,14 +192,31 @@ export const animate = (
     // Use cameraRef for synchronous access (avoids stale state issues)
     // Fall back to props.camera for backward compatibility
     const cameraValues = props.cameraRef?.current ?? props.camera;
-    if (cameraValues && cameraValues.zoom !== 1) {
+    if (cameraValues) {
       ctx.save();
       // Calculate the center point to zoom towards (in canvas coordinates)
       const cameraCenterX = cameraValues.cx * canvas.width;
       const cameraCenterY = cameraValues.cy * canvas.height;
 
-      // Calculate the viewport center
-      const viewportCenterX = canvas.width / 2 + (props.sidebarWidth ?? 0) / 2;
+      // The focused-sun framing shifts the view right by half the sidebar so the
+      // target lands in the centre of the *visible* area (right of the sidebar),
+      // matching the Zoom Out button at left: calc(50% + sidebarWidth/2) (#212).
+      // That offset must FADE OUT as the camera returns to the full view: the
+      // zoom-out target is zoom=1, and the old `zoom !== 1` guard applied the full
+      // shift right up to zoom=1 and then dropped it on the settle frame — snapping
+      // the whole field left by sidebarWidth/2. Ramp the offset from 0 at zoom=1 to
+      // full by minSunFocusZoom, so every focused state keeps #212's centring while
+      // zoom-out settles smoothly. At zoom=1 / cx=cy=0.5 the transform is identity,
+      // so the default view is pixel-unchanged.
+      const sidebarShift = (props.sidebarWidth ?? 0) / 2;
+      const offsetFactor = Math.min(
+        1,
+        Math.max(
+          0,
+          (cameraValues.zoom - 1) / (CAMERA_CONFIG.minSunFocusZoom - 1),
+        ),
+      );
+      const viewportCenterX = canvas.width / 2 + sidebarShift * offsetFactor;
       const viewportCenterY = canvas.height / 2;
 
       // Apply transformation to center the camera target in the visible viewport
@@ -643,10 +661,10 @@ export const animate = (
 
     updateStarActivity(currentStars);
 
-    // Restore canvas context if camera transformation was applied
-    // Must match the save condition: cameraValues && cameraValues.zoom !== 1
+    // Restore canvas context if camera transformation was applied.
+    // Must match the save condition above (any truthy camera → transform applied).
     const cameraForRestore = props.cameraRef?.current ?? props.camera;
-    if (cameraForRestore && cameraForRestore.zoom !== 1) {
+    if (cameraForRestore) {
       ctx.restore();
     }
 


### PR DESCRIPTION
## Problem
Zooming **out** from a focused sun (Return to Stars / clicking the focused sun) ends with the whole starfield **snapping sideways** by ~`sidebarWidth/2` (≈110px on desktop) on the final frame. Zoom-*in* was already centred (#212); zoom-*out* was not.

## Root cause
In `animate.ts` the camera transform that shifts the view right by `sidebarWidth/2` — so a focused sun lands in the centre of the *visible* area (right of the sidebar), matching the Zoom Out button at `left: calc(50% + sidebarWidth/2)` (#212) — was gated on `cameraValues.zoom !== 1`:

```js
if (cameraValues && cameraValues.zoom !== 1) {
  const viewportCenterX = canvas.width / 2 + (props.sidebarWidth ?? 0) / 2;
  ...
}
```

The zoom-out target is `zoom: 1`. So the **full** sidebar shift stays applied right up to `zoom = 1`, then the transform switches off entirely on the settle frame → the field jumps left by `sidebarWidth/2`. That discontinuity is the "off-centre" snap.

## Fix
Apply the camera transform **continuously** and **ramp the sidebar offset from 0 at `zoom = 1` to full by `minSunFocusZoom` (1.8)**:

```js
const offsetFactor = clamp((zoom - 1) / (minSunFocusZoom - 1), 0, 1);
const viewportCenterX = canvas.width / 2 + (sidebarWidth / 2) * offsetFactor;
```

- At `zoom = 1, cx = cy = 0.5` the transform is the **identity** → the default view is pixel-unchanged.
- At any focus zoom (1.8–3.0) `offsetFactor = 1` → **full** offset → #212's focused-sun centring is preserved exactly.
- In between, the offset fades smoothly, so zoom-out settles with **no jump**.

The matching `ctx.restore()` guard is updated to stay balanced with the (now unconditional) `ctx.save()`.

## Scope / risk
- One file, `animate.ts` (+24/-6). CSS/render-only; no behavioural change at either rest state (default or focused) — only the transition trajectory is smoothed. Cannot introduce a new snap.

## Verification
- Bug + fix confirmed by exact code reading and continuity math (snap was `sidebarWidth/2`; now continuous).
- `pnpm build:web` green (deploy gate).
- Final visual confirmation best done on the running site (headless canvas-zoom interaction wasn't drivable reliably).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport centering and camera transform behavior for more consistent visual presentation when zooming and adjusting focus within the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->