### PR TITLE
chore(deps): make Renovate sole update authority

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
           - Development:
               - Overview: main/guides/development/README.md
               - Code Style: main/guides/development/code-style.md
+              - Dependency Updates: main/guides/development/dependency-updates.md
               - Dev Containers: main/guides/development/dev-containers.md
               - Development Setup: main/guides/development/development-setup.md
               - Search Functionality: main/guides/development/search-functionality.md

--- a/docs/src/main/guides/development/README.md
+++ b/docs/src/main/guides/development/README.md
@@ -7,6 +7,7 @@ This folder contains all the documentation related to local development, coding 
 - [Overview](#overview)
 - [Development Setup](#development-setup)
 - [Code Style](#code-style)
+- [Dependency Updates](#dependency-updates)
 - [Dev Containers](#dev-containers)
 - [Search Functionality](#search-functionality)
 - [Additional Resources](#additional-resources)
@@ -23,6 +24,10 @@ Here you’ll find everything you need to get started contributing to the codeba
 ## Code Style {: #code-style}
 - **[code-style.md](./code-style.md)**
   Outlines our conventions for writing clean, maintainable JavaScript/TypeScript code, React components, Node.js services, and more. This guide also details linting (ESLint), formatting (Prettier), and testing conventions.
+
+## Dependency Updates {: #dependency-updates}
+- **[dependency-updates.md](./dependency-updates.md)**
+  Defines Renovate as the sole dependency-update pull request authority, while retaining Dependabot alerts for vulnerability detection.
 
 ## Dev Containers {: #dev-containers}
 - **[dev-containers.md](./dev-containers.md)**

--- a/docs/src/main/guides/development/dependency-updates.md
+++ b/docs/src/main/guides/development/dependency-updates.md
@@ -1,0 +1,39 @@
+# Dependency Updates
+
+Renovate is the repository's only dependency-update pull request authority.
+GitHub Dependabot alerts remain enabled as a detection signal, but Dependabot
+version-update configuration and automated security-fix pull requests must stay
+disabled. This keeps GitHub's vulnerability reporting without creating
+competing update branches.
+
+## Renovate policy
+
+- Vulnerability-remediation pull requests are created immediately and labelled
+  `security` and `dependencies`.
+- Routine updates wait for explicit approval in the Renovate Dependency
+  Dashboard before Renovate creates a branch or pull request.
+- Dependency pull requests never automerge. The repository's normal review,
+  build, and branch-protection gates still apply.
+- Renovate creates at most two pull requests per hour and rebases branches that
+  fall behind the default branch.
+- Storybook packages update as one pinned package family so core, addons,
+  framework adapters, and ESLint integration cannot drift to incompatible
+  versions.
+- MkDocs ecosystem packages update together so one strict documentation build
+  verifies the complete toolchain.
+- Major updates receive the `breaking-change` label.
+
+## Review requirements
+
+Before merging, refresh the pull request's exact head and base, review the
+dependency and lockfile diff, and run the checks appropriate to the affected
+workspace. A visible lint check alone is not sufficient. Examples include:
+
+- web or design-system type-check and production build for frontend tooling;
+- API TypeScript build for server dependencies;
+- static Storybook build for Storybook changes; and
+- locked Poetry install plus strict MkDocs build for documentation packages.
+
+Keep dependency alerts separate from update automation: disabling Dependabot
+pull requests must not disable GitHub vulnerability alerts or the dependency
+graph.

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,54 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":dependencyDashboardApproval",
+    "group:storybookMonorepo"
+  ],
+  "automerge": false,
+  "dependencyDashboard": true,
+  "labels": [
+    "dependencies"
+  ],
+  "prHourlyLimit": 2,
+  "rebaseWhen": "behind-base-branch",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "dependencyDashboardApproval": false,
+    "labels": [
+      "dependencies",
+      "security"
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Keep the Storybook package family atomic and exactly aligned.",
+      "matchPackageNames": [
+        "storybook",
+        "eslint-plugin-storybook",
+        "@storybook/**"
+      ],
+      "groupName": "storybook monorepo",
+      "rangeStrategy": "pin"
+    },
+    {
+      "description": "Group the documentation toolchain for one strict MkDocs verification.",
+      "matchPackageNames": [
+        "mkdocs",
+        "mkdocs-*",
+        "pymdown-extensions"
+      ],
+      "groupName": "MkDocs ecosystem",
+      "groupSlug": "mkdocs-ecosystem"
+    },
+    {
+      "description": "Flag breaking upgrades for explicit review.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "addLabels": [
+        "breaking-change"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- require Dependency Dashboard approval for routine Renovate updates while keeping vulnerability remediation immediate
- disable dependency automerge, rate-limit PR creation, and rebase stale update branches
- keep Storybook updates atomic and pinned, group the MkDocs ecosystem, and label major upgrades
- document Renovate as the sole update-PR authority while retaining Dependabot alerts for detection

## Live repository evidence

- GitHub vulnerability alerts: enabled
- Dependabot automated security fixes: disabled
- dependabot.yml: absent
- all open dependency PRs: Renovate-authored

## Validation

- current Renovate 44.16.1 config validator in strict mode
- strict Linux Python 3.12/native-Cairo MkDocs production build
- full repository pre-commit lint: pass with one pre-existing Starfield hook warning
- git diff --check

## Tooling note

Renovate's local-platform dry-run runner did not complete reliably on this Windows host: an initial invocation used an invalid explicit repository argument, and the corrected local lookup run hung beyond its cap. Strict config validation passed; the hosted Renovate run remains the authoritative behavioral refresh after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Development guide explaining dependency update automation, security alerts, update policies, review requirements, and validation checks.
  * Added the new guide to the documentation navigation and table of contents.

* **Chores**
  * Updated dependency-management settings to group related updates, apply labels, limit pull requests, require approval, and keep automatic merging disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->